### PR TITLE
Adjust voltage card's max range

### DIFF
--- a/web-app/src/components/cards/Voltage.vue
+++ b/web-app/src/components/cards/Voltage.vue
@@ -114,7 +114,7 @@ export default {
       return {
         yaxis: {
           min: 2.4,
-          max: 4.2
+          max: 4.4
         }
       }
     },


### PR DESCRIPTION
Fixes #46 

Go to Trevor's weather station which reports a max voltage of 4.4 when you set the time scope to 90 days. Now it is no longer being cut off. @SuperShadowPlay I believe your station's voltage reading is off by +0.15 volts (should be reporting 4.25 when it says 4.4). Either way, I think bumping the upper limit helps other stations with a constant 4.2 reading from clinging to the top edge of the graph.